### PR TITLE
Extend t_reassembly

### DIFF
--- a/include/srsran/asn1/rrc_nr/rrc_nr.h
+++ b/include/srsran/asn1/rrc_nr/rrc_nr.h
@@ -8979,13 +8979,21 @@ struct t_reassembly_opts {
     ms180,
     ms190,
     ms200,
+    ms210,
+    ms220,
+    ms340,
+    ms350,
+    ms550,
+    ms1100,
+    ms1650,
+    ms2220,
     spare1,
     nulltype
   } value;
-  typedef uint8_t number_type;
+  typedef uint16_t number_type;
 
   const char* to_string() const;
-  uint8_t     to_number() const;
+  uint16_t     to_number() const;
 };
 typedef enumerated<t_reassembly_opts> t_reassembly_e;
 

--- a/lib/asn1/rrc_nr/rrc_nr.cpp
+++ b/lib/asn1/rrc_nr/rrc_nr.cpp
@@ -21838,14 +21838,16 @@ const char* t_reassembly_opts::to_string() const
   static const char* names[] = {"ms0",   "ms5",   "ms10",  "ms15",  "ms20",  "ms25",  "ms30",  "ms35",
                                 "ms40",  "ms45",  "ms50",  "ms55",  "ms60",  "ms65",  "ms70",  "ms75",
                                 "ms80",  "ms85",  "ms90",  "ms95",  "ms100", "ms110", "ms120", "ms130",
-                                "ms140", "ms150", "ms160", "ms170", "ms180", "ms190", "ms200", "spare1"};
-  return convert_enum_idx(names, 32, value, "t_reassembly_e");
+                                "ms140", "ms150", "ms160", "ms170", "ms180", "ms190", "ms200", "ms210",
+                                "ms220", "ms340", "ms350", "ms550", "ms1100", "ms1650", "ms2220", "spare1"};
+  return convert_enum_idx(names, 40, value, "t_reassembly_e");
 }
-uint8_t t_reassembly_opts::to_number() const
+uint16_t t_reassembly_opts::to_number() const
 {
-  static const uint8_t numbers[] = {0,  5,  10, 15, 20,  25,  30,  35,  40,  45,  50,  55,  60,  65,  70, 75,
-                                    80, 85, 90, 95, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200};
-  return map_enum_number(numbers, 31, value, "t_reassembly_e");
+  static const uint16_t numbers[] = {0,  5,  10, 15, 20,  25,  30,  35,  40,  45,  50,  55,  60,  65,  70, 75,
+                                    80, 85, 90, 95, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200, 210,
+                                    220, 340, 350, 550, 1100, 1650, 2220};
+  return map_enum_number(numbers, 39, value, "t_reassembly_e");
 }
 
 // T-StatusProhibit ::= ENUMERATED


### PR DESCRIPTION
Extend `t_reassembly` enum to prepare it to larger values.

 [Specification  38.821 version 16.1.0](https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=3525)

Section `7.2.2.1`
`t-Reassembly = RTD * nrof_HARQ_retrans + scheduling_offset`