### PR TITLE
Extend HARQ processes to 32

### DIFF
--- a/apps/gnb/gnb_appconfig_translators.cpp
+++ b/apps/gnb/gnb_appconfig_translators.cpp
@@ -383,7 +383,7 @@ std::vector<upper_phy_config> srsran::generate_du_low_config(const gnb_appconfig
     // Calculate the maximum number of users assuming the CORESET above.
     unsigned max_nof_users_slot = coreset.get_nof_cces();
     // Assume a maximum of 16 HARQ processes.
-    unsigned max_harq_process = 16;
+    unsigned max_harq_process = 32;
     // Assume the maximum number of active UL HARQ processes is twice the maximum number of users per slot for the
     // maximum number of HARQ processes.
     unsigned max_softbuffers = 2 * max_nof_users_slot * max_harq_process;

--- a/include/srsran/scheduler/harq_id.h
+++ b/include/srsran/scheduler/harq_id.h
@@ -25,7 +25,7 @@
 namespace srsran {
 
 /// Identification of an HARQ process.
-enum harq_id_t : uint8_t { MAX_HARQ_ID = 15, MAX_NOF_HARQS = 16, INVALID_HARQ_ID = 16 };
+enum harq_id_t : uint8_t { MAX_HARQ_ID = 31, MAX_NOF_HARQS = 32, INVALID_HARQ_ID = 32 };
 
 constexpr inline harq_id_t to_harq_id(unsigned h_id)
 {

--- a/lib/fapi/validators/message_validators.cpp
+++ b/lib/fapi/validators/message_validators.cpp
@@ -206,7 +206,7 @@ static bool validate_rapid(unsigned value, message_type_id msg_id, validator_rep
 static bool validate_harq_id(unsigned value, message_type_id msg_id, validator_report& report)
 {
   static constexpr unsigned MIN_VALUE = 0;
-  static constexpr unsigned MAX_VALUE = 15;
+  static constexpr unsigned MAX_VALUE = 31;
 
   return validate_field(MIN_VALUE, MAX_VALUE, value, "HARQ ID", msg_id, report);
 }

--- a/tests/unittests/fapi/validators/crc_indication_test.cpp
+++ b/tests/unittests/fapi/validators/crc_indication_test.cpp
@@ -95,7 +95,7 @@ INSTANTIATE_TEST_SUITE_P(HARQ,
                                           testing::Values(test_case_data{0, true},
                                                           test_case_data{8, true},
                                                           test_case_data{15, true},
-                                                          test_case_data{16, false})));
+                                                          test_case_data{32, false})));
 
 INSTANTIATE_TEST_SUITE_P(TA,
                          validate_crc_message_field,

--- a/tests/unittests/fapi/validators/rx_data_indication_test.cpp
+++ b/tests/unittests/fapi/validators/rx_data_indication_test.cpp
@@ -100,7 +100,7 @@ INSTANTIATE_TEST_SUITE_P(HarqID,
                                           testing::Values(test_case_data{0, true},
                                                           test_case_data{8, true},
                                                           test_case_data{15, true},
-                                                          test_case_data{16, false})));
+                                                          test_case_data{32, false})));
 
 INSTANTIATE_TEST_SUITE_P(PDUTag,
                          validate_rx_data_indication_field,
@@ -146,7 +146,7 @@ TEST(validate_rx_data_indication, invalid_indication_fails)
   auto msg = build_valid_rx_data_indication();
 
   msg.pdus.back().rapid   = 64U;
-  msg.pdus.back().harq_id = 16U;
+  msg.pdus.back().harq_id = 32U;
   msg.pdus.back().pdu_tag = rx_data_indication_pdu::pdu_tag_type::MAC_PDU;
 
   const auto& result = validate_rx_data_indication(msg);


### PR DESCRIPTION
 [Specification  38.821 version 16.1.0](https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=3525)

Section `6.4.2` HARQ Optimization for NR NTN