### PR TITLE
Fix nof_dmrs_prb

### DIFF
--- a/tests/benchmarks/phy/upper/channel_processors/pdsch_processor_benchmark.cpp
+++ b/tests/benchmarks/phy/upper/channel_processors/pdsch_processor_benchmark.cpp
@@ -361,7 +361,7 @@ static std::vector<test_case_type> generate_test_cases(const test_profile& profi
         tbs_config.n_prb                        = nof_prb;
         tbs_config.nof_layers                   = precoding_config.get_nof_layers();
         tbs_config.nof_symb_sh                  = profile.nof_symbols;
-        tbs_config.nof_dmrs_prb                 = dmrs.nof_dmrs_per_rb() * dmrs_symbol_mask.count();
+        tbs_config.nof_dmrs_prb                 = dmrs.nof_dmrs_per_rb() * dmrs_symbol_mask.count() * nof_cdm_groups_without_data;
         unsigned tbs                            = tbs_calculator_calculate(tbs_config);
 
         // Build the PDSCH PDU configuration.

--- a/tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark.cpp
+++ b/tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark.cpp
@@ -302,7 +302,7 @@ static std::vector<test_case_type> generate_test_cases(const test_profile& profi
       tbs_config.n_prb                        = nof_prb;
       tbs_config.nof_layers                   = nof_tx_layers;
       tbs_config.nof_symb_sh                  = profile.nof_symbols;
-      tbs_config.nof_dmrs_prb                 = dmrs.nof_dmrs_per_rb() * dmrs_symbol_mask.count();
+      tbs_config.nof_dmrs_prb                 = dmrs.nof_dmrs_per_rb() * dmrs_symbol_mask.count() * nof_cdm_groups_without_data;
       unsigned tbs                            = tbs_calculator_calculate(tbs_config);
 
       // Build the PUSCH PDU configuration.


### PR DESCRIPTION
**ISSUE**
TBS calculation takes into account the number of DMRS REs. However, the number of CDM groups without data, in both pxsch_processor_benchmarks, has been omitted resulting to wrong TBS calculation.
