### PR TITLE
docker - use `cmake --build` instead of make

### DIFF
--- a/docker/scripts/builder.sh
+++ b/docker/scripts/builder.sh
@@ -215,5 +215,5 @@ ccache -z || true
 mkdir -p "$BUILD_FOLDER"
 cd "$BUILD_FOLDER" || exit
 cmake $CCACHE_CMAKE_ARGS "$@" ..
-make $MAKE_EXTRA
+cmake --build . -- $MAKE_EXTRA
 ccache -sv || true


### PR DESCRIPTION
This should allow using other cmake generators (specifically ninja) instead of makefiles.