### PR TITLE
Fix missing gnb command line parameters

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       5gc:
         condition: service_healthy
     # Command to run into the final container
-    command: gnb -c /gnb_config.yml amf --addr ${OPEN5GS_IP:-10.53.1.2} --bind_addr ${GNB_IP:-10.53.1.3}
+    command: gnb -c /gnb_config.yml
 
   metrics-server:
     container_name: metrics_server
@@ -140,7 +140,7 @@ services:
 
 configs:
   gnb_config.yml:
-    file: ${GNB_CONFIG_PATH:-../configs/gnb_rf_b200_tdd_n78_20mhz.yml} # Path to your desired config file
+    file: ${GNB_CONFIG_PATH:-../configs/gnb_rf_b200_tdd_n78_20mhz.yml} # Path to your desired config file and configure cu_cp.amf.addr (i.e. 10.53.1.2) and cu_cp.amf.bind_addr (i.e. 10.53.1.3) values.
 
 volumes:
   gnb-storage:


### PR DESCRIPTION
Hi,

Since the latest version of gnb, `amf` parameter is no longer supported.

In the current docker-compose.yaml to execute gnb program, `amf --addr ${OPEN5GS_IP:-10.53.1.2} --bind_addr ${GNB_IP:-10.53.1.3}` throw an error.

I propose a fix in this PR. Both `addr` and `bind_addr` options must be specified in the desired the configuration file.

Best