### PR TITLE
Implement GPIO signalling for when transmitting/not.

### DIFF
--- a/apps/examples/radio/radio_util_sample.cpp
+++ b/apps/examples/radio/radio_util_sample.cpp
@@ -297,7 +297,7 @@ int main(int argc, char** argv)
   config.clock.clock      = radio_configuration::clock_sources::source::DEFAULT;
   config.sampling_rate_hz = sampling_rate_hz;
   config.otw_format       = otw_format;
-  config.tx_mode          = enable_discontinuous_tx ? radio_configuration::transmission_mode::discontinuous
+  config.tx_mode          = enable_discontinuous_tx ? radio_configuration::transmission_mode::discontinuous_idle
                                                     : radio_configuration::transmission_mode::continuous;
   config.power_ramping_us = power_ramping_us;
   config.args             = device_arguments;

--- a/apps/units/flexible_du/split_8/helpers/ru_sdr_config.h
+++ b/apps/units/flexible_du/split_8/helpers/ru_sdr_config.h
@@ -28,6 +28,27 @@
 
 namespace srsran {
 
+/// GPIO TX indication sector configuration.
+struct ru_sdr_unit_expert_config_gpio_tx_sector {
+  /// \brief GPIO pin to indicate TX status on (optional)
+  std::optional<unsigned> gpio_index;
+  /// \brief Sense of the GPIO pin for indicating TX status
+  ///
+  /// True outputs a high when transmitting, false outputs a low when
+  /// transmitting.
+  bool sense = false;
+  /// \brief Source of the GPIO signal, either "idle" or "config"
+  std::string source = "idle";
+  /// \brief Amount of time to put GPIO in TX mode early in microseconds.
+  float prelude = 0.0F;
+};
+
+/// GPIO TX indication cell configuration.
+struct ru_sdr_unit_expert_config_gpio_tx_cell {
+  // Per sector config
+  std::vector<ru_sdr_unit_expert_config_gpio_tx_sector> sectors;
+};
+
 /// Expert SDR Radio Unit configuration.
 struct ru_sdr_unit_expert_config {
   /// System time-based throttling. See \ref lower_phy_configuration::system_time_throttling for more information.
@@ -36,8 +57,10 @@ struct ru_sdr_unit_expert_config {
   ///
   /// Selects the radio transmission mode between the available options:
   ///   - continuous: The radio keeps the transmitter chain active, even when there are no transmission requests.
-  ///   - discontinuous: The transmitter stops when there is no data to transmit.
-  ///   - same-port: like discontinuous mode, but using the same port to transmit and receive.
+  ///   - discontinuous-idle: The transmitter stops when there is no data to transmit.
+  ///   - discontinuous-config: The transmitter stops when not in TX portion of TDD config.
+  ///   - same-port-idle: like discontinuous-idle mode, but using the same port to transmit and receive.
+  ///   - same-port-config: like discontinuous-config mode, but using the same port to transmit and receive.
   ///
   /// \remark The discontinuous and same-port transmission modes may not be supported for some radio devices.
   std::string transmission_mode = "continuous";
@@ -58,6 +81,15 @@ struct ru_sdr_unit_expert_config {
   /// \note Powering up the transmitter ahead of time requires starting the transmission earlier, and reduces the time
   /// window for the radio to transmit the provided samples.
   float power_ramping_time_us = 0.0F;
+  /// \brief Time the PPS goes high. Usually 0.0, but on some radios later.
+  ///
+  /// E.g. on an N310 this can be 101.3 us.
+  float pps_time_offset_us = 0.0f;
+  /// Number of samples to offset the tx/rx time by, used to compensate for
+  /// radio offsets. Positive means start tx later/report rx as being later.
+  int sample_offset = 0;
+  /// \brief The per sector per cell configuration of the TX GPIOs
+  std::vector<ru_sdr_unit_expert_config_gpio_tx_cell> gpio_tx_cells;
   /// \brief Lower PHY downlink baseband buffer size policy.
   ///
   /// Selects the size policy of the baseband buffers that pass DL samples from the lower PHY to the radio.

--- a/apps/units/flexible_du/split_8/helpers/ru_sdr_config_validator.cpp
+++ b/apps/units/flexible_du/split_8/helpers/ru_sdr_config_validator.cpp
@@ -102,7 +102,9 @@ static bool validate_ru_sdr_appconfig(const ru_sdr_unit_config&                 
 
   const bool discontinuous_transmission = (config.expert_cfg.transmission_mode != "continuous");
   for (const auto& cell : cell_config) {
-    if ((config.expert_cfg.transmission_mode == "same-port") && (cell.dplx_mode == duplex_mode::FDD)) {
+    if ((config.expert_cfg.transmission_mode == "same-port-idle"
+         || config.expert_cfg.transmission_mode == "same-port-config")
+            && (cell.dplx_mode == duplex_mode::FDD)) {
       fmt::print("same-port transmission mode cannot be used with FDD cell configurations.\n");
       return false;
     }

--- a/apps/units/flexible_du/split_8/helpers/ru_sdr_config_yaml_writer.cpp
+++ b/apps/units/flexible_du/split_8/helpers/ru_sdr_config_yaml_writer.cpp
@@ -115,6 +115,31 @@ static void fill_ru_sdr_section(YAML::Node node, const ru_sdr_unit_config& confi
     expert_node["low_phy_dl_throttling"] = config.expert_cfg.lphy_dl_throttling;
     expert_node["tx_mode"]               = config.expert_cfg.transmission_mode;
     expert_node["power_ramping_time_us"] = config.expert_cfg.power_ramping_time_us;
+    expert_node["pps_time_offset_us"]    = config.expert_cfg.pps_time_offset_us;
+    expert_node["sample_offset"]         = config.expert_cfg.sample_offset;
+    auto gpio_tx_cells = expert_node["gpio_tx_cells"];
+    while (config.expert_cfg.gpio_tx_cells.size() > gpio_tx_cells.size()) {
+      gpio_tx_cells.push_back(YAML::Node());
+    }
+    for (unsigned i = 0; i != config.expert_cfg.gpio_tx_cells.size(); ++i) {
+      auto gpio_tx_sectors = gpio_tx_cells[i]["sectors"];
+      auto config_gpio_tx_sectors =
+          config.expert_cfg.gpio_tx_cells[i].sectors;
+
+      while (config_gpio_tx_sectors.size() > gpio_tx_sectors.size()) {
+        gpio_tx_cells.push_back(YAML::Node());
+      }
+
+      for (unsigned j = 0; j != config_gpio_tx_sectors.size(); ++j) {
+        if (config_gpio_tx_sectors[j].gpio_index.has_value()) {
+          gpio_tx_sectors[j]["gpio_index"] =
+              config_gpio_tx_sectors[j].gpio_index.value();
+          gpio_tx_sectors[j]["sense"] = config_gpio_tx_sectors[j].sense;
+          gpio_tx_sectors[j]["source"] = config_gpio_tx_sectors[j].source;
+          gpio_tx_sectors[j]["prelude"] = config_gpio_tx_sectors[j].prelude;
+        }
+      }
+    }
     expert_node["dl_buffer_size_policy"] = config.expert_cfg.dl_buffer_size_policy;
   }
 }

--- a/include/srsran/gateways/baseband/baseband_gateway_transmitter_metadata.h
+++ b/include/srsran/gateways/baseband/baseband_gateway_transmitter_metadata.h
@@ -48,6 +48,16 @@ struct baseband_gateway_transmitter_metadata {
   /// If present, it is the sample index in which there is no signal until the end of the buffer. Otherwise, the
   /// baseband buffer contains transmit signal until the last sample.
   std::optional<unsigned> tx_end;
+  /// \brief Downlink period start according to the TDD config in samples.
+  ///
+  /// If present, sample previous it was not part of the downlink period and it
+  /// is part of the downlink period.
+  std::optional<unsigned> dl_config_start;
+  /// \brief Downlink period end according to the TDD config in samples.
+  ///
+  /// If present, sample previous it was part of the downlink period and it is
+  /// not part of the downlink period.
+  std::optional<unsigned> dl_config_end;
 };
 
 } // namespace srsran

--- a/include/srsran/phy/lower/lower_phy_configuration.h
+++ b/include/srsran/phy/lower/lower_phy_configuration.h
@@ -35,6 +35,7 @@
 #include "srsran/ran/cyclic_prefix.h"
 #include "srsran/ran/n_ta_offset.h"
 #include "srsran/ran/subcarrier_spacing.h"
+#include "srsran/ran/tdd/tdd_ul_dl_config.h"
 #include "srsran/srslog/srslog.h"
 #include "srsran/support/executors/task_executor.h"
 
@@ -52,6 +53,8 @@ struct lower_phy_sector_description {
   unsigned nof_tx_ports;
   /// Number of receive ports.
   unsigned nof_rx_ports;
+  /// TDD Configuration
+  std::optional<tdd_ul_dl_config_common> tdd_config;
 };
 
 /// \brief Lower physical layer baseband gateway buffer size policy.

--- a/include/srsran/phy/lower/processors/downlink/downlink_processor_factories.h
+++ b/include/srsran/phy/lower/processors/downlink/downlink_processor_factories.h
@@ -26,6 +26,7 @@
 #include "srsran/phy/lower/processors/downlink/downlink_processor.h"
 #include "srsran/phy/lower/processors/downlink/pdxch/pdxch_processor_factories.h"
 #include "srsran/phy/lower/sampling_rate.h"
+#include "srsran/ran/tdd/tdd_ul_dl_config.h"
 #include <memory>
 
 namespace srsran {
@@ -40,6 +41,8 @@ struct downlink_processor_configuration {
   cyclic_prefix cp;
   /// Baseband sampling rate.
   sampling_rate rate;
+  /// TDD Config
+  std::optional<tdd_ul_dl_config_common> tdd_config;
   /// Bandwidth in PRB.
   unsigned bandwidth_prb;
   /// Center frequency in Hz.

--- a/include/srsran/ran/tdd/tdd_ul_dl_config.h
+++ b/include/srsran/ran/tdd/tdd_ul_dl_config.h
@@ -112,4 +112,19 @@ std::optional<unsigned> find_next_tdd_ul_slot(const tdd_ul_dl_config_common& cfg
 /// start_slot_index being >= TDD period in slots.
 std::optional<unsigned> find_next_tdd_full_ul_slot(const tdd_ul_dl_config_common& cfg, unsigned start_slot_index = 0);
 
+/// \brief Determines if this is the first DL symbol
+/// \return True if this is the first dl symbol (e.g. after UL). Else false.
+bool is_first_tdd_dl_symbol(const tdd_ul_dl_config_common& cfg,
+                            unsigned slot_index,
+                            unsigned symbol_index,
+                            cyclic_prefix cp);
+
+/// \brief Determines if this is the last DL symbol (e.g. before a gap to UL)
+/// \return True if this is the last dl symbol (e.g. before swap to ul).
+/// Else false.
+bool is_last_tdd_dl_symbol(const tdd_ul_dl_config_common& cfg,
+                           unsigned slot_index,
+                           unsigned symbol_index,
+                           cyclic_prefix cp);
+
 } // namespace srsran

--- a/lib/ofh/timing/realtime_timing_worker.cpp
+++ b/lib/ofh/timing/realtime_timing_worker.cpp
@@ -76,6 +76,7 @@ realtime_timing_worker::realtime_timing_worker(srslog::basic_logger&      logger
   logger(logger_),
   executor(executor_),
   scs(cfg.scs),
+  cp(cfg.cp),
   nof_symbols_per_slot(get_nsymb_per_slot(cfg.cp)),
   nof_symbols_per_sec(nof_symbols_per_slot * get_nof_slots_per_subframe(scs) * NOF_SUBFRAMES_PER_FRAME * 100),
   symbol_duration(1e9 / nof_symbols_per_sec),

--- a/lib/ofh/timing/realtime_timing_worker.h
+++ b/lib/ofh/timing/realtime_timing_worker.h
@@ -58,6 +58,7 @@ class realtime_timing_worker : public controller, public ota_symbol_boundary_not
   std::vector<ota_symbol_boundary_notifier*>     ota_notifiers;
   task_executor&                                 executor;
   const subcarrier_spacing                       scs;
+  const cyclic_prefix                            cp;
   const unsigned                                 nof_symbols_per_slot;
   const unsigned                                 nof_symbols_per_sec;
   const std::chrono::duration<double, std::nano> symbol_duration;

--- a/lib/phy/lower/lower_phy_factory.cpp
+++ b/lib/phy/lower/lower_phy_factory.cpp
@@ -131,8 +131,9 @@ public:
     // Get transmit time offset between the UL and the DL.
     int tx_time_offset = get_tx_time_offset(config.time_alignment_calibration, config.ta_offset, config.srate);
 
-    // Maximum time delay between reception and transmission in samples (1ms plus the time offset).
-    unsigned rx_to_tx_max_delay = config.srate.to_kHz() + tx_time_offset;
+    // Maximum time delay between reception and transmission in samples (1ms
+    // plus, no time offset as the processor adds this after).
+    unsigned rx_to_tx_max_delay = config.srate.to_kHz();
 
     // Prepare downlink processor configuration.
     downlink_processor_configuration dl_proc_config;
@@ -140,6 +141,7 @@ public:
     dl_proc_config.scs                     = config.scs;
     dl_proc_config.cp                      = config.cp;
     dl_proc_config.rate                    = config.srate;
+    dl_proc_config.tdd_config              = sector.tdd_config;
     dl_proc_config.bandwidth_prb           = sector.bandwidth_rb;
     dl_proc_config.center_frequency_Hz     = sector.dl_freq_hz;
     dl_proc_config.nof_tx_ports            = sector.nof_tx_ports;
@@ -177,7 +179,7 @@ public:
     proc_bb_adaptor_config.nof_tx_ports           = config.sectors.back().nof_tx_ports;
     proc_bb_adaptor_config.nof_rx_ports           = config.sectors.back().nof_rx_ports;
     proc_bb_adaptor_config.tx_time_offset         = tx_time_offset;
-    proc_bb_adaptor_config.rx_to_tx_max_delay     = config.srate.to_kHz() + proc_bb_adaptor_config.tx_time_offset;
+    proc_bb_adaptor_config.rx_to_tx_max_delay     = config.srate.to_kHz();
     proc_bb_adaptor_config.rx_buffer_size         = rx_buffer_size;
     proc_bb_adaptor_config.nof_rx_buffers         = std::max(4U, rx_to_tx_max_delay / rx_buffer_size);
     proc_bb_adaptor_config.tx_buffer_size         = tx_buffer_size;

--- a/lib/phy/lower/processors/downlink/CMakeLists.txt
+++ b/lib/phy/lower/processors/downlink/CMakeLists.txt
@@ -25,4 +25,4 @@ add_library(srsran_lower_phy_downlink_processor STATIC
         downlink_processor_factories.cpp
         downlink_processor_impl.cpp)
 
-target_link_libraries(srsran_lower_phy_downlink_processor srsvec)
+target_link_libraries(srsran_lower_phy_downlink_processor srsvec srsran_ran)

--- a/lib/phy/lower/processors/downlink/downlink_processor_baseband_impl.h
+++ b/lib/phy/lower/processors/downlink/downlink_processor_baseband_impl.h
@@ -31,6 +31,7 @@
 #include "srsran/phy/lower/processors/downlink/pdxch/pdxch_processor_baseband.h"
 #include "srsran/phy/lower/sampling_rate.h"
 #include "srsran/ran/cyclic_prefix.h"
+#include "srsran/ran/tdd/tdd_ul_dl_config.h"
 #include "srsran/support/stats.h"
 
 namespace srsran {
@@ -45,6 +46,8 @@ struct downlink_processor_baseband_configuration {
   cyclic_prefix cp;
   /// Baseband sampling rate.
   sampling_rate rate;
+  /// TDD Config
+  std::optional<tdd_ul_dl_config_common> tdd_config;
   /// Number of transmit ports.
   unsigned nof_tx_ports;
   /// Number of slots notified in advance in the TTI boundary event.
@@ -216,6 +219,10 @@ private:
   unsigned sector_id;
   /// Subcarrier spacing.
   subcarrier_spacing scs;
+  /// Cyclic prefix configuration.
+  cyclic_prefix cp;
+  /// TDD Config.
+  std::optional<tdd_ul_dl_config_common> tdd_config;
   /// Number of receive ports.
   unsigned nof_rx_ports;
   /// Number of samples per subframe;
@@ -232,6 +239,9 @@ private:
   detail::baseband_symbol_buffer temp_buffer;
   /// Last notified slot boundary.
   std::optional<slot_point> last_notified_slot;
+
+  /// Hold stop time for the symbol in the temp_buffer.
+  std::optional<baseband_gateway_timestamp> hold_stop_time;
 };
 
 } // namespace srsran

--- a/lib/phy/lower/processors/downlink/downlink_processor_factories.cpp
+++ b/lib/phy/lower/processors/downlink/downlink_processor_factories.cpp
@@ -54,6 +54,7 @@ public:
     baseband_config.scs                     = config.scs;
     baseband_config.cp                      = config.cp;
     baseband_config.rate                    = config.rate;
+    baseband_config.tdd_config              = config.tdd_config;
     baseband_config.nof_tx_ports            = config.nof_tx_ports;
     baseband_config.nof_slot_tti_in_advance = config.nof_slot_tti_in_advance;
 

--- a/lib/radio/uhd/radio_uhd_rx_stream.h
+++ b/lib/radio/uhd/radio_uhd_rx_stream.h
@@ -49,6 +49,9 @@ private:
   unsigned id;
   /// Sampling rate in hertz.
   double srate_Hz;
+  /// Number of samples to offset the tx/rx time by, used to compensate for
+  /// radio offsets. Positive means start tx later/report rx as being later.
+  int sample_offset;
   /// Radio notification interface.
   radio_notification_handler& notifier;
   /// Owns the UHD Tx stream.
@@ -78,6 +81,9 @@ public:
     unsigned id;
     /// Sampling rate in hertz.
     double srate_Hz;
+    /// Number of samples to offset the tx/rx time by, used to compensate for
+    /// radio offsets. Positive means start tx later/report rx as being later.
+    int sample_offset;
     /// Over-the-wire format.
     radio_configuration::over_the_wire_format otw_format;
     /// Stream arguments.

--- a/lib/radio/uhd/radio_uhd_tx_stream.cpp
+++ b/lib/radio/uhd/radio_uhd_tx_stream.cpp
@@ -60,12 +60,12 @@ void radio_uhd_tx_stream::recv_async_msg()
       break;
     case uhd::async_metadata_t::EVENT_CODE_TIME_ERROR:
       event_description.type = radio_notification_handler::event_type::LATE;
-      state_fsm.async_event_late_underflow(async_metadata.time_spec);
+      state_fsm.async_event_late_underflow(async_metadata.time_spec - sample_offset);
       break;
     case uhd::async_metadata_t::EVENT_CODE_UNDERFLOW:
     case uhd::async_metadata_t::EVENT_CODE_UNDERFLOW_IN_PACKET:
       event_description.type = radio_notification_handler::event_type::UNDERFLOW;
-      state_fsm.async_event_late_underflow(async_metadata.time_spec);
+      state_fsm.async_event_late_underflow(async_metadata.time_spec - sample_offset);
       break;
     case uhd::async_metadata_t::EVENT_CODE_SEQ_ERROR:
     case uhd::async_metadata_t::EVENT_CODE_SEQ_ERROR_IN_BURST:
@@ -124,7 +124,7 @@ bool radio_uhd_tx_stream::transmit_block(unsigned&                             n
   });
 }
 
-radio_uhd_tx_stream::radio_uhd_tx_stream(uhd::usrp::multi_usrp::sptr& usrp,
+radio_uhd_tx_stream::radio_uhd_tx_stream(uhd::usrp::multi_usrp::sptr& usrp_,
                                          const stream_description&    description,
                                          task_executor&               async_executor_,
                                          radio_notification_handler&  notifier_) :
@@ -132,8 +132,13 @@ radio_uhd_tx_stream::radio_uhd_tx_stream(uhd::usrp::multi_usrp::sptr& usrp,
   async_executor(async_executor_),
   notifier(notifier_),
   srate_hz(description.srate_hz),
+  sample_offset(description.sample_offset),
   nof_channels(description.ports.size()),
-  discontinuous_tx(description.discontiuous_tx),
+  discontinuous_tx(description.discontinuous_tx),
+  discontinuous_config(description.discontinuous_config),
+  gpio_tx_index(description.gpio_tx_index),
+  gpio_tx_sense(description.gpio_tx_sense),
+  gpio_tx_use_config(description.gpio_tx_use_config),
   last_tx_timespec(0.0),
   power_ramping_buffer(nof_channels, 0)
 {
@@ -157,13 +162,23 @@ radio_uhd_tx_stream::radio_uhd_tx_stream(uhd::usrp::multi_usrp::sptr& usrp,
   stream_args.args     = description.args;
   stream_args.channels = description.ports;
 
-  if (!safe_execution([this, usrp, &stream_args]() {
+  if (!safe_execution([this, usrp_, &stream_args]() {
+        usrp = usrp_;
+        if (gpio_tx_index.has_value()) {
+          uint32_t pin_mask = 1 << gpio_tx_index.value();
+          usrp->set_gpio_attr("FP0", "CTRL", 0, pin_mask);
+          usrp->set_gpio_attr("FP0", "OUT", gpio_tx_sense ? 0 : pin_mask,
+                  pin_mask); // set RX
+          usrp->set_gpio_attr("FP0", "DDR", pin_mask, pin_mask);
+        }
         stream          = usrp->get_tx_stream(stream_args);
         max_packet_size = stream->get_max_num_samps();
       })) {
     printf("Error:  failed to create transmit stream %d. %s.\n", stream_id, get_error_message().c_str());
     return;
   }
+
+  gpio_tx_prelude_samples = description.gpio_tx_prelude * description.srate_hz / 1e6;
 
   // Use zero padding to absorb power ramping on each new burst.
   if (discontinuous_tx) {
@@ -190,6 +205,67 @@ radio_uhd_tx_stream::radio_uhd_tx_stream(uhd::usrp::multi_usrp::sptr& usrp,
   run_recv_async_msg();
 }
 
+template<class T>
+static void sanitize_start_end_last(
+    bool last_on,
+    std::optional<T>& start,
+    std::optional<T>& end) {
+  if (start.has_value() && end.has_value() && start.value() == end.value()) {
+    start.reset();
+    end.reset();
+  }
+  if (last_on && start.has_value() && end.has_value()
+      && start.value() < end.value()) {
+    start.reset();
+  }
+  if (!last_on && start.has_value() && end.has_value()
+      && start.value() > end.value()) {
+    end.reset();
+  }
+}
+
+// Assumes that start/end have been sanitized with sanitize_start_end_last.
+template<class T>
+static void update_last(
+    bool& last_on,
+    const std::optional<T>& start,
+    const std::optional<T>& end) {
+  if (start.has_value()) {
+    if (!end.has_value()) {
+      last_on = true;
+    } else {
+      last_on = start.value() > end.value();
+    }
+  } else if (end.has_value()) {
+    last_on = false;
+  }
+}
+
+template<class T>
+static bool is_1(
+    const T& time,
+    const bool last_on,
+    const std::optional<T>& start,
+    const std::optional<T>& end) {
+  if (last_on) {
+    if (!end.has_value()) {
+      return true;
+    } else {
+      return time < end.value();
+    }
+  } else {
+    if (!start.has_value()) {
+      return false;
+    } else if (!end.has_value()) {
+      return time >= start.value();
+    } else {
+      return time >= start.value() && time < end.value();
+    }
+  }
+
+  // Impossible
+}
+
 void radio_uhd_tx_stream::transmit(const baseband_gateway_buffer_reader&        data,
                                    const baseband_gateway_transmitter_metadata& tx_md)
 {
@@ -198,123 +274,374 @@ void radio_uhd_tx_stream::transmit(const baseband_gateway_buffer_reader&        
 
   uhd::tx_metadata_t uhd_metadata;
 
-  bool tx_start_padding = tx_md.tx_start.has_value();
-  bool tx_end_padding   = tx_md.tx_end.has_value();
+  std::optional<uhd::time_spec_t> idle_start_time_spec;
+  std::optional<uhd::time_spec_t> idle_end_time_spec;
+  bool idle_extend_end = false;
 
-  uhd::time_spec_t time_spec = time_spec.from_ticks(tx_md.ts, srate_hz);
-  bool             transmit;
-  if (discontinuous_tx) {
-    if (tx_start_padding) {
-      // Set the timespec to the start of the actual transmission if there is head padding in the buffer.
-      time_spec =
-          time_spec.from_ticks(tx_md.ts + static_cast<baseband_gateway_timestamp>(tx_md.tx_start.value()), srate_hz);
-    }
-    // Update state.
-    transmit = state_fsm.on_transmit(uhd_metadata, time_spec, tx_md.is_empty, tx_end_padding);
+  unsigned idle_start_index = 0;
+  unsigned idle_end_index = data.get_nof_samples();
+
+  std::optional<uhd::time_spec_t> start_time_spec;
+  std::optional<uhd::time_spec_t> end_time_spec;
+
+  unsigned start_index;
+  unsigned end_index;
+
+  std::optional<uhd::time_spec_t> dl_config_start_ts;
+  std::optional<uhd::time_spec_t> dl_config_end_ts;
+  bool dl_config_extend_end = false;
+
+  unsigned dl_config_start_index = 0;
+  unsigned dl_config_end_index = data.get_nof_samples();
+
+  unsigned end_extension_count = 0;
+  uhd::time_spec_t end_extension_ts =
+      uhd::time_spec_t::from_ticks(0, srate_hz);
+
+  // Subtracting sample offset because radio seems to have a shifted view
+  // between GPIO and samples, doesn't work well without this and I think
+  // it's because the GPIO is turning off the PA early.
+  if (sample_offset < 0) {
+    end_extension_count = -sample_offset;
+    end_extension_ts = uhd::time_spec_t::from_ticks(
+            end_extension_count, srate_hz);
+  }
+
+  if (tx_md.tx_start.has_value()) {
+    // Start at specified time
+    idle_start_time_spec = uhd::time_spec_t::from_ticks(tx_md.ts
+            + static_cast<baseband_gateway_timestamp>(tx_md.tx_start.value()),
+            srate_hz);
+    idle_start_index = tx_md.tx_start.value();
   } else {
-    transmit = state_fsm.on_transmit(uhd_metadata, time_spec, false, false);
-  }
-
-  // Return if no transmission is required.
-  if (!transmit) {
-    return;
-  }
-
-  // Notify start of burst.
-  if (uhd_metadata.start_of_burst) {
-    radio_notification_handler::event_description event_description;
-    event_description.stream_id  = stream_id;
-    event_description.channel_id = 0;
-    event_description.source     = radio_notification_handler::event_source::TRANSMIT;
-    event_description.type       = radio_notification_handler::event_type::START_OF_BURST;
-    event_description.timestamp.emplace(time_spec.to_ticks(srate_hz));
-    notifier.on_radio_rt_event(event_description);
-
-    // Transmit zeros before the actual transmission to absorb power ramping effects.
-    if (discontinuous_tx) {
-      // Compute the time in number of samples between the end of the last transmission and the start of the current
-      // one.
-      unsigned transmission_gap = (time_spec - last_tx_timespec).to_ticks(srate_hz);
-
-      // Make sure that the power ramping padding starts at least 10 microseconds after the last transmission end.
-      unsigned minimum_gap_before_power_ramping = srate_hz / 100000.0;
-      unsigned nof_padding_samples              = 0;
-      if (transmission_gap > minimum_gap_before_power_ramping) {
-        nof_padding_samples = std::min(power_ramping_nof_samples, transmission_gap - minimum_gap_before_power_ramping);
-      }
-
-      if (nof_padding_samples > 0) {
-        unsigned txd_padding_sps_total = 0;
-
-        uhd::tx_metadata_t power_ramping_metadata;
-        power_ramping_metadata.has_time_spec  = true;
-        power_ramping_metadata.start_of_burst = true;
-        power_ramping_metadata.end_of_burst   = false;
-        power_ramping_metadata.time_spec = uhd_metadata.time_spec - time_spec.from_ticks(nof_padding_samples, srate_hz);
-
-        // Modify the actual trasnmission metadata, since we have already started the burst with padding.
-        uhd_metadata.start_of_burst = false;
-        uhd_metadata.has_time_spec  = false;
-        do {
-          unsigned txd_samples = 0;
-
-          baseband_gateway_buffer_reader_view tx_padding =
-              baseband_gateway_buffer_reader_view(power_ramping_buffer.get_reader(), 0, nof_padding_samples);
-
-          if (!transmit_block(txd_samples, tx_padding, txd_padding_sps_total, power_ramping_metadata)) {
-            printf("Error: failed transmitting power ramping padding. %s.\n", get_error_message().c_str());
-            return;
-          }
-
-          power_ramping_metadata.time_spec += txd_samples * srate_hz;
-          txd_padding_sps_total += txd_samples;
-
-        } while (txd_padding_sps_total < nof_padding_samples);
-      }
+    // If not empty and not currently running start at beginning
+    if (!tx_md.is_empty && !last_sample_state_tx) {
+      idle_start_time_spec = uhd::time_spec_t::from_ticks(tx_md.ts, srate_hz);
     }
   }
 
-  // Notify end of burst.
-  if (uhd_metadata.end_of_burst) {
-    radio_notification_handler::event_description event_description;
-    event_description.stream_id  = stream_id;
-    event_description.channel_id = 0;
-    event_description.source     = radio_notification_handler::event_source::TRANSMIT;
-    event_description.type       = radio_notification_handler::event_type::END_OF_BURST;
-    event_description.timestamp.emplace(time_spec.to_ticks(srate_hz));
-    notifier.on_radio_rt_event(event_description);
+  if (tx_md.tx_end.has_value()) {
+    // End at specified time
+    idle_end_time_spec = uhd::time_spec_t::from_ticks(tx_md.ts
+          + static_cast<baseband_gateway_timestamp>(tx_md.tx_end.value()),
+          srate_hz);
+    idle_end_index = tx_md.tx_end.value();
+    idle_extend_end = true;
+  } else {
+    // If empty and was running, stop at beginning
+    if (tx_md.is_empty && last_sample_state_tx) {
+      idle_end_time_spec = uhd::time_spec_t::from_ticks(tx_md.ts, srate_hz);
+      idle_end_index = 0;
+    }
+  }
+
+  if (tx_md.dl_config_start.has_value() && tx_md.dl_config_end.has_value()) {
+    srsran_assert(tx_md.dl_config_start.value() < tx_md.dl_config_end.value(),
+        "This code doesn't support an end before start on the TDD config in "
+        "one block!");
+  }
+
+  sanitize_start_end_last(last_sample_state_tx, idle_start_time_spec,
+          idle_end_time_spec);
+
+  std::optional<unsigned> dl_config_start = tx_md.dl_config_start;
+  std::optional<unsigned> dl_config_end = tx_md.dl_config_end;
+
+  sanitize_start_end_last(last_tdd_config_state_tx,
+      dl_config_start, dl_config_end);
+
+  // If there's a dl_config_start, push the start of the transmission back to
+  // that point
+  if (dl_config_start.has_value()) {
+    dl_config_start_index = dl_config_start.value();
+    dl_config_start_ts = uhd::time_spec_t::from_ticks(
+        tx_md.ts + dl_config_start_index, srate_hz);
+    if (is_1(dl_config_start_ts.value(), last_sample_state_tx,
+          idle_start_time_spec, idle_end_time_spec)) {
+      // If transmission ends before TDD config start, cancel it
+      if (idle_end_time_spec.has_value() &&
+          idle_end_time_spec.value() <= dl_config_start_ts.value()) {
+        idle_start_time_spec.reset();
+        idle_end_time_spec.reset();
+        idle_end_index = data.get_nof_samples();
+      } else {
+        idle_start_time_spec = dl_config_start_ts.value();
+        idle_start_index = dl_config_start_index;
+      }
+    }
+  // If we're not in a TDD config transmit, cancel the transmission, but mark
+  // as running (for next TDD config start)
+  } else if (!last_tdd_config_state_tx) {
+    idle_start_time_spec.reset();
+    idle_end_time_spec.reset();
+    last_sample_state_tx = true;
+  }
+
+  // If there's a dl_config_end, pull the end of the transmission back to that
+  // point
+  if (dl_config_end.has_value()) {
+    dl_config_end_index = dl_config_end.value();
+    dl_config_end_ts = uhd::time_spec_t::from_ticks(
+        tx_md.ts + dl_config_end_index, srate_hz);
+    dl_config_extend_end = true;
+    if (is_1(dl_config_end_ts.value(), last_sample_state_tx,
+          idle_start_time_spec, idle_end_time_spec)) {
+      // If transmission starts after TDD config end, cancel it
+      if (idle_start_time_spec.has_value()
+          && dl_config_end_ts <= idle_start_time_spec.value()) {
+        idle_start_time_spec.reset();
+        idle_end_time_spec.reset();
+        idle_end_index = data.get_nof_samples();
+      } else {
+        idle_end_time_spec = dl_config_end_ts.value();
+        idle_end_index = dl_config_end_index;
+        idle_extend_end = true;
+      }
+    }
+  } // No else because if we're already running the start/end passes through
+
+  update_last(last_sample_state_tx, idle_start_time_spec, idle_end_time_spec);
+  update_last(last_tdd_config_state_tx, dl_config_start, dl_config_end);
+
+  if (discontinuous_config) {
+    start_time_spec = dl_config_start_ts;
+    start_index = dl_config_start_index;
+    end_time_spec = dl_config_end_ts;
+    end_index = dl_config_end_index;
+
+    if (dl_config_extend_end) {
+      if (end_time_spec.has_value()) {
+        end_time_spec.value() += end_extension_ts;
+      }
+      end_index += end_extension_count;
+    }
+  } else {
+    start_time_spec = idle_start_time_spec;
+    start_index = idle_start_index;
+    end_time_spec = idle_end_time_spec;
+    end_index = idle_end_index;
+
+    if (idle_extend_end) {
+      if (end_time_spec.has_value()) {
+        end_time_spec.value() += end_extension_ts;
+      }
+      end_index += end_extension_count;
+    }
+  }
+
+  bool has_tx_start = start_time_spec.has_value();
+  bool has_tx_end   = end_time_spec.has_value();
+
+  uhd::time_spec_t time_spec            =
+      time_spec.from_ticks(tx_md.ts, srate_hz);
+  bool             transmit;
+  bool             start_of_tx          = false;
+  bool             end_of_tx            = false;
+  bool             force_start_of_burst = false;
+  bool             force_end_of_burst   = false;
+  bool             start_of_burst;
+  bool             end_of_burst;
+
+  if (has_tx_start && discontinuous_tx) {
+    // Time actual transmission will start (regardless of when samples start)
+    time_spec = start_time_spec.value();
+  }
+
+  // Update state.
+  transmit = state_fsm.on_transmit(
+          discontinuous_tx, time_spec, start_of_tx, end_of_tx,
+          force_start_of_burst, force_end_of_burst,
+          tx_md.is_empty, has_tx_end);
+  start_of_burst = force_start_of_burst;
+  end_of_burst = force_end_of_burst;
+
+  if(discontinuous_tx) {
+      uhd_metadata.start_of_burst |= start_of_tx;
+      uhd_metadata.end_of_burst |= end_of_tx;
+  }
+
+  // For restarting a late/underflowed transmission
+  uhd_metadata.start_of_burst |= start_of_burst;
+  uhd_metadata.end_of_burst |= end_of_burst;
+
+  if (start_of_burst) {
+    // Is getting forced on for whatever exceptional reason.
+    last_sample_state_tx = true;
+  }
+  if (end_of_burst) {
+    // Is getting forced off for whatever exceptional reason.
+    last_sample_state_tx = false;
   }
 
   // Determine actual transmission range.
-  unsigned data_start = discontinuous_tx && tx_start_padding ? tx_md.tx_start.value() : 0;
-  unsigned data_nof_samples =
-      discontinuous_tx && tx_end_padding ? tx_md.tx_end.value() - data_start : data.get_nof_samples() - data_start;
+  unsigned data_start = discontinuous_tx ? start_index : 0;
+  unsigned data_nof_samples = discontinuous_tx ?
+    end_index - start_index
+    : data.get_nof_samples();
 
-  // Don't pass the transmission data to UHD if the transmit buffer is empty.
-  baseband_gateway_buffer_reader_view tx_data =
-      discontinuous_tx && tx_md.is_empty ? baseband_gateway_buffer_reader_view(data, 0, 0)
-                                         : baseband_gateway_buffer_reader_view(data, data_start, data_nof_samples);
+  if (gpio_tx_index.has_value()) {
+    uint32_t pin_mask = 1 << gpio_tx_index.value();
+    bool clear_time = false;
 
-  unsigned nsamples = tx_data.get_nof_samples();
+    std::optional<uhd::time_spec_t> gpio_start_time;
+    std::optional<uhd::time_spec_t> gpio_end_time;
 
-  // Transmit stream in multiple blocks.
-  unsigned txd_samples_total = 0;
-  do {
-    unsigned txd_samples = 0;
-    if (!transmit_block(txd_samples, tx_data, txd_samples_total, uhd_metadata)) {
-      printf("Error: failed transmitting packet. %s.\n", get_error_message().c_str());
-      return;
+    // Determine start time (if there is one)
+    if (force_start_of_burst) {
+      gpio_start_time = time_spec;
+    } else {
+      if (gpio_tx_use_config) {
+        if (dl_config_start_ts.has_value()) {
+          gpio_start_time = dl_config_start_ts.value();
+        }
+      } else {
+        if (idle_start_time_spec.has_value()) {
+          gpio_start_time = idle_start_time_spec.value();
+        }
+      }
     }
 
-    // Increment timespec.
-    uhd_metadata.time_spec += txd_samples * srate_hz;
+    if (gpio_start_time.has_value()) {
+      gpio_start_time.value() -= uhd::time_spec_t::from_ticks(
+              gpio_tx_prelude_samples, srate_hz);
+    }
 
-    // Increment the total amount of received samples.
-    txd_samples_total += txd_samples;
 
-  } while (txd_samples_total < nsamples);
+    // Determine end time (if there is one)
+    if (force_end_of_burst) {
+      gpio_end_time = time_spec + uhd::time_spec_t::from_ticks(
+              data_nof_samples, srate_hz);
+    } else {
+      if (gpio_tx_use_config) {
+        if (dl_config_end_ts.has_value()) {
+          gpio_end_time = dl_config_end_ts.value();
+        }
+      } else {
+        if (idle_end_time_spec.has_value()) {
+          gpio_end_time = idle_end_time_spec.value();
+        }
+      }
+    }
 
-  last_tx_timespec = time_spec + uhd::time_spec_t::from_ticks(txd_samples_total, srate_hz);
+    // Actually set the GPIO
+    if (gpio_start_time.has_value()) {
+      usrp->set_command_time(gpio_start_time.value());
+      clear_time = true;
+      usrp->set_gpio_attr("FP0", "OUT",
+          gpio_tx_sense ? pin_mask : 0, pin_mask);
+    }
+
+    if (gpio_end_time.has_value()) {
+      usrp->set_command_time(gpio_end_time.value());
+      clear_time = true;
+      usrp->set_gpio_attr("FP0", "OUT",
+          gpio_tx_sense ? 0 : pin_mask, pin_mask);
+    }
+    if (clear_time) {
+      usrp->clear_command_time();
+    }
+  }
+
+  // Skip if no transmission is required.
+  if (transmit) {
+    if(uhd_metadata.start_of_burst) {
+        uhd_metadata.has_time_spec = true;
+        uhd_metadata.time_spec = time_spec
+            + uhd::time_spec_t::from_ticks(sample_offset, srate_hz);
+    }
+
+    // Notify start of burst.
+    if (uhd_metadata.start_of_burst) {
+      radio_notification_handler::event_description event_description;
+      event_description.stream_id  = stream_id;
+      event_description.channel_id = 0;
+      event_description.source     = radio_notification_handler::event_source::TRANSMIT;
+      event_description.type       = radio_notification_handler::event_type::START_OF_BURST;
+      event_description.timestamp.emplace(time_spec.to_ticks(srate_hz));
+      notifier.on_radio_rt_event(event_description);
+
+      // Transmit zeros before the actual transmission to absorb power ramping effects.
+      if (discontinuous_tx) {
+        // Compute the time in number of samples between the end of the last transmission and the start of the current
+        // one.
+        unsigned transmission_gap = (time_spec - last_tx_timespec).to_ticks(srate_hz);
+
+        // Make sure that the power ramping padding starts at least 10 microseconds after the last transmission end.
+        unsigned minimum_gap_before_power_ramping = srate_hz / 100000.0;
+        unsigned nof_padding_samples              = 0;
+        if (transmission_gap > minimum_gap_before_power_ramping) {
+          nof_padding_samples = std::min(power_ramping_nof_samples, transmission_gap - minimum_gap_before_power_ramping);
+        }
+
+        if (nof_padding_samples > 0) {
+          unsigned txd_padding_sps_total = 0;
+
+          uhd::tx_metadata_t power_ramping_metadata;
+          power_ramping_metadata.has_time_spec  = true;
+          power_ramping_metadata.start_of_burst = true;
+          power_ramping_metadata.end_of_burst   = false;
+          power_ramping_metadata.time_spec = uhd_metadata.time_spec - time_spec.from_ticks(nof_padding_samples, srate_hz);
+
+          // Modify the actual trasnmission metadata, since we have already started the burst with padding.
+          uhd_metadata.start_of_burst = false;
+          uhd_metadata.has_time_spec  = false;
+          do {
+            unsigned txd_samples = 0;
+
+            baseband_gateway_buffer_reader_view tx_padding =
+                baseband_gateway_buffer_reader_view(power_ramping_buffer.get_reader(), 0, nof_padding_samples);
+
+            if (!transmit_block(txd_samples, tx_padding, txd_padding_sps_total, power_ramping_metadata)) {
+              printf("Error: failed transmitting power ramping padding. %s.\n", get_error_message().c_str());
+              return;
+            }
+
+            power_ramping_metadata.time_spec += txd_samples * srate_hz;
+            txd_padding_sps_total += txd_samples;
+
+          } while (txd_padding_sps_total < nof_padding_samples);
+        }
+      }
+    }
+
+    // Notify end of burst.
+    if (uhd_metadata.end_of_burst) {
+      radio_notification_handler::event_description event_description;
+      event_description.stream_id  = stream_id;
+      event_description.channel_id = 0;
+      event_description.source     = radio_notification_handler::event_source::TRANSMIT;
+      event_description.type       = radio_notification_handler::event_type::END_OF_BURST;
+      event_description.timestamp.emplace(time_spec.to_ticks(srate_hz));
+      notifier.on_radio_rt_event(event_description);
+    }
+
+    // Don't pass the transmission data to UHD if the transmit buffer is empty.
+    baseband_gateway_buffer_reader_view tx_data =
+        discontinuous_tx && tx_md.is_empty ? baseband_gateway_buffer_reader_view(data, 0, 0)
+                                           : baseband_gateway_buffer_reader_view(data, data_start, data_nof_samples);
+
+    unsigned nsamples = tx_data.get_nof_samples();
+
+    // Transmit stream in multiple blocks.
+    unsigned txd_samples_total = 0;
+    do {
+      unsigned txd_samples = 0;
+      if (!transmit_block(txd_samples, tx_data, txd_samples_total, uhd_metadata)) {
+        printf("Error: failed transmitting packet. %s.\n", get_error_message().c_str());
+        return;
+      }
+
+      // Increment timespec.
+      uhd_metadata.time_spec +=
+        uhd::time_spec_t::from_ticks(txd_samples, srate_hz);
+
+      // Increment the total amount of received samples.
+      txd_samples_total += txd_samples;
+
+    } while (txd_samples_total < nsamples);
+
+    last_tx_timespec = time_spec + uhd::time_spec_t::from_ticks(txd_samples_total, srate_hz);
+  }
 }
 
 void radio_uhd_tx_stream::stop()

--- a/lib/ran/tdd_ul_dl_config.cpp
+++ b/lib/ran/tdd_ul_dl_config.cpp
@@ -158,3 +158,50 @@ std::optional<unsigned> srsran::find_next_tdd_full_ul_slot(const tdd_ul_dl_confi
   }
   return ret;
 }
+
+bool srsran::is_first_tdd_dl_symbol(const tdd_ul_dl_config_common& cfg,
+                                    unsigned slot_index,
+                                    unsigned symbol_index,
+                                    cyclic_prefix cp)
+{
+  // All periods are integer number of slots, all slot configuration periods
+  // start with DL, therefore first symbol MUST be first symbol of slot
+  if(symbol_index != 0) {
+    return false;
+  }
+
+  // By TS 38.213 11.1, first symbol every 20/P is a first symbol of frame
+  if(slot_index == 0) {
+    return true;
+  } else {
+    if(!has_active_tdd_dl_symbols(cfg, slot_index)) {
+      return false;
+    } else {
+      // Previous slot wasn't a full DL slot
+      return nof_active_symbols(cfg, slot_index-1, cp, true)
+              < nof_slots_per_tdd_period(cfg);
+    }
+  }
+
+  // Impossible
+}
+
+bool srsran::is_last_tdd_dl_symbol(const tdd_ul_dl_config_common& cfg,
+                                   unsigned slot_index,
+                                   unsigned symbol_index,
+                                   cyclic_prefix cp)
+{
+  if(is_tdd_full_dl_slot(cfg, slot_index)) {
+    if(symbol_index == get_nsymb_per_slot(cp) - 1) {
+      return !has_active_tdd_dl_symbols(cfg, slot_index+1);
+    } else {
+      return false;
+    }
+  } else {
+    return symbol_index+1 ==
+        get_active_tdd_dl_symbols(cfg, slot_index, cp).stop();
+  }
+
+  // Impossible
+}
+

--- a/tests/unittests/radio/zmq/radio_zmq_validator_test.cpp
+++ b/tests/unittests/radio/zmq/radio_zmq_validator_test.cpp
@@ -243,7 +243,7 @@ const std::vector<test_case_t> radio_zmq_validator_test_data = {
      "Only default OTW format is currently supported.\n"},
     {[] {
        radio_configuration::radio config = radio_base_config;
-       config.tx_mode                    = radio_configuration::transmission_mode::discontinuous;
+       config.tx_mode                    = radio_configuration::transmission_mode::discontinuous_idle;
        return config;
      },
      "Discontinuous transmission modes are not supported by the ZMQ radio.\n"},


### PR DESCRIPTION
This feature is separate from the tx_mode which controls whether the tx stream is started and stopped.
Configuration options:
* Pin to output on (gpio_index)
* Whether to output high or low on transmit (sense)
* How many microseconds to set the tx output early (to turn on external PAs, switches, etc) (prelude)
* Whether to source from idle or config (source)
* Offset between PPS and real time (pps_time_offset_us)
* Offset in samples between sample time and everything else (sample_offset)

TDD Config start/stop piped down to radio layer.

In lib/phy/lower/lower_phy_factory.cpp removed the adding of tx_time_offset to
    the max delay as this was already handled by the processor. Processor
    checks the max delay against it's version of timestamp, processes symbols
    based on such timestamp, but then sends the symbols out tx_time_offset
    late. Therefore the max delay is being between two timeframes offset by
    tx_time_offset, so the tx_time_offset term is already accounted for.

Add sample offset to align RF and GPIO (and PA which uses GPIO). SDR does not line up it's time for everything else (e.g. GPIO) with the sample time (i.e. RF). Therefore the transmit time needs to be brought up by a certain number of samples. Similarly the end needs to be extended so the SDR doesn't shut off the PA on itself (it is truly confused about time).

Stitch together start/end from both sources.
Fixups to transmit FSM to keep underflow restart working.

Add configuration for whether to use idle or config for TX and GPIO.

Add PPS time offset parameter to compensate for 101.3 us offset in N310.