### PR TITLE
asn1: fix for byte buffer to uint64_t helper

### DIFF
--- a/lib/asn1/asn1_utils.cpp
+++ b/lib/asn1/asn1_utils.cpp
@@ -957,7 +957,7 @@ uint64_t octet_string_helper::to_uint(const byte_buffer& buf)
   uint64_t val = 0;
   auto     it  = buf.begin();
   for (unsigned i = 0; i < nbytes; ++i) {
-    val += static_cast<uint64_t>(*it) << static_cast<uint64_t>((nbytes - 1 - i) * 8U);
+    val |= (static_cast<uint64_t>(*it) & 0xffu) << static_cast<uint64_t>(i * 8U);
     ++it;
   }
   return val;


### PR DESCRIPTION
Hi,

This is a proposal of a fix in the function that converts a byte_buffer to a uint64_t value.

Currently, when the size of a byte_buffer is greater than 1, the code mistakenly converts the bytes into an incorrect uint64_t value.

The `static_cast<uint64_t>((nbytes - 1 - i) * 8U)` erroneously inverts the order of the bits in the resulting value, so that functions `void octet_string_helper::to_octet_string(srsran::byte_buffer& buf, uint64_t number)` and `uint64_t octet_string_helper::to_uint(const byte_buffer& buf)` are not equivalent.