### PR TITLE
uhd: change multiplication with division in timespec calculation

### DIFF
--- a/lib/radio/uhd/radio_uhd_tx_stream.cpp
+++ b/lib/radio/uhd/radio_uhd_tx_stream.cpp
@@ -307,7 +307,7 @@ void radio_uhd_tx_stream::transmit(const baseband_gateway_buffer_reader&        
     }
 
     // Increment timespec.
-    uhd_metadata.time_spec += txd_samples * srate_hz;
+    uhd_metadata.time_spec += txd_samples / srate_hz;
 
     // Increment the total amount of received samples.
     txd_samples_total += txd_samples;


### PR DESCRIPTION
When the samples are trasmitted, time_spec needs to be updated.
Correct calculation should be: (time taken) = (transmitted samples) / (sampling frequency).