### PR TITLE
du: do not encode an empty CellGroupConfig in make_empty_ue_config()

### DIFF
--- a/lib/du/du_high/du_manager/procedures/ue_configuration_procedure.cpp
+++ b/lib/du/du_high/du_manager/procedures/ue_configuration_procedure.cpp
@@ -434,14 +434,6 @@ f1ap_ue_context_update_response ue_configuration_procedure::make_empty_ue_config
 {
   f1ap_ue_context_update_response resp;
   resp.result = true;
-  // > Calculate ASN.1 CellGroupConfig to be sent in DU-to-CU container.
-  asn1::rrc_nr::cell_group_cfg_s asn1_cell_group;
-  // Pack cellGroupConfig.
-  {
-    asn1::bit_ref     bref{resp.cell_group_cfg};
-    asn1::SRSASN_CODE code = asn1_cell_group.pack(bref);
-    srsran_assert(code == asn1::SRSASN_SUCCESS, "Invalid cellGroupConfig");
-  }
   return resp;
 }
 


### PR DESCRIPTION
Hello srsRAN team,

while working on interoperability between srsRAN DU and openairinterface CU I found an issue.

When we get the UL message containing RRC Reconfiguration Complete, our CU sends to your DU RRCReconfigurationCompleteIndicator inside an UEContextModificationRequest. Then your DU replies with an UEContextModificationResponse containing a DUtoCURRCInformation with an empty CellGroupConfig.

This CellGroupConfig is then forwarded by the CU to the UE as per 38.473 8.3.4.2.

Then our CU will receive another UL message containing RRC Reconfiguration Complete, leading to sending another RRCReconfigurationCompleteIndicator and this process repeats indefinitely.

If not required by some specifications, I propose to remove the empty CellGroupConfig from DUtoCURRCInformation.

I identified the function make_empty_ue_config() as the place where the modification needs to be done.

I attach a pcap for inspection.

I am open to discussion, naturally.

[cellgroupconfig-infinite-loop.pcap.gz](https://github.com/user-attachments/files/21364453/cellgroupconfig-infinite-loop.pcap.gz)