### PR TITLE
docker: support all gNB deployment scenarios for metrics

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,24 +1,34 @@
 ## Telegraf
-# WS_URL: WebSocket URL for connecting to gNB metrics endpoint
 #
-# Choose ONE of the following options based on your deployment:
+# WS_URL: WebSocket endpoint for gNB metrics
 #
-# Option 1: gNB running inside Docker (using docker-compose.yml)
-#   Use the container name or Docker network IP
-#   WS_URL=gnb:8001
-#   WS_URL=172.19.1.3:8001
+# ============================================================================
+# Choose ONE option based on your gNB deployment:
+# ============================================================================
 #
-# Option 2: gNB running on the Docker host (external gNB)
-#   Use the host IP address where gNB is running
-#   WS_URL=<HOST_IP>:8001
-#   Example: WS_URL=192.168.1.100:8001
+# [A] gNB in Docker (using docker-compose.yml together)
+#     WS_URL=gnb:8001
 #
-# Option 3: gNB running on the same machine as Docker (Linux)
-#   Use host.docker.internal or the host's IP
-#   WS_URL=host.docker.internal:8001
+# [B] gNB on Host machine (native build, not in Docker)
+#     WS_URL=host.docker.internal:8001
 #
-# Default: Assumes gNB is running inside Docker network
-WS_URL=172.19.1.3:8001
+# [C] gNB in Kubernetes (via NodePort or Service)
+#     WS_URL=<K8S_NODE_IP>:<NODE_PORT>
+#     Example: WS_URL=10.0.0.50:30801
+#     Or use K8s service DNS: WS_URL=<service>.<namespace>.svc.cluster.local:8001
+#
+# [D] gNB on Remote server
+#     WS_URL=<REMOTE_IP>:8001
+#     Example: WS_URL=192.168.1.100:8001
+#
+# ----------------------------------------------------------------------------
+# Linux note: If host.docker.internal doesn't resolve, use one of:
+#   - Docker bridge gateway: WS_URL=172.17.0.1:8001
+#   - Your host's actual IP: WS_URL=$(hostname -I | awk '{print $1}'):8001
+# ----------------------------------------------------------------------------
+#
+# Default: gNB running inside Docker (Option A)
+WS_URL=gnb:8001
 
 TELEGRAF_VERSION=1.35.0
 TELEGRAF_INPUT_INTERVAL=1s

--- a/docker/.env
+++ b/docker/.env
@@ -1,6 +1,24 @@
 ## Telegraf
+# WS_URL: WebSocket URL for connecting to gNB metrics endpoint
+#
+# Choose ONE of the following options based on your deployment:
+#
+# Option 1: gNB running inside Docker (using docker-compose.yml)
+#   Use the container name or Docker network IP
+#   WS_URL=gnb:8001
+#   WS_URL=172.19.1.3:8001
+#
+# Option 2: gNB running on the Docker host (external gNB)
+#   Use the host IP address where gNB is running
+#   WS_URL=<HOST_IP>:8001
+#   Example: WS_URL=192.168.1.100:8001
+#
+# Option 3: gNB running on the same machine as Docker (Linux)
+#   Use host.docker.internal or the host's IP
+#   WS_URL=host.docker.internal:8001
+#
+# Default: Assumes gNB is running inside Docker network
 WS_URL=172.19.1.3:8001
-# WS_URL=gnb:8001
 
 TELEGRAF_VERSION=1.35.0
 TELEGRAF_INPUT_INTERVAL=1s

--- a/docker/README.md
+++ b/docker/README.md
@@ -177,6 +177,54 @@ Change the environment variables define in `.env` that are used to setup and dep
 └── ...
 ```
 
+#### Connecting to an External gNB
+
+When running the monitoring stack (`docker-compose.ui.yml`) with a gNB that runs **outside** of Docker (e.g., on the host machine or another server), you need to configure `WS_URL` in the `.env` file to point to the gNB's WebSocket server.
+
+**Steps:**
+
+1. Ensure your gNB configuration includes:
+   ```yaml
+   remote_control:
+     enabled: true
+     bind_addr: 0.0.0.0    # Important: bind to all interfaces
+
+   metrics:
+     enable_json: true
+   ```
+
+2. Update `WS_URL` in `docker/.env`:
+   ```bash
+   # Replace <GNB_HOST_IP> with your gNB's IP address
+   WS_URL=<GNB_HOST_IP>:8001
+
+   # Example: gNB running on 192.168.1.100
+   WS_URL=192.168.1.100:8001
+
+   # Example: gNB running on the same machine (Linux)
+   WS_URL=host.docker.internal:8001
+   ```
+
+3. Start the monitoring stack:
+   ```bash
+   docker compose -f docker/docker-compose.ui.yml up
+   ```
+
+4. Verify connectivity by checking Telegraf logs:
+   ```bash
+   docker logs telegraf
+   ```
+
+**Troubleshooting:**
+- If Grafana shows "No data", check that `WS_URL` is correctly set to reach your gNB
+- Verify gNB is running and shows: `Remote control server listening on 0.0.0.0:8001`
+- Test WebSocket connectivity manually:
+  ```bash
+  cd docker/telegraf
+  WS_URL="<GNB_HOST_IP>:8001" python3 ws_adapter.py
+  ```
+  You should see JSON metrics output if the connection is successful.
+
 You can access grafana in <http://localhost:3300>. By default, you'll be in view mode without needing to log in. If you want to modify anything, you need to log in using following credentials:
 
 - username: `admin`

--- a/docker/docker-compose.ui.yml
+++ b/docker/docker-compose.ui.yml
@@ -29,6 +29,9 @@ services:
         condition: service_healthy
     env_file:
       - .env
+    # Enable host.docker.internal on Linux (works by default on Docker Desktop for Mac/Windows)
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # volumes:
     #   - /tmp/metrics.txt:/etc/srs/metrics.txt:ro # Uncomment to use an input metrics file
     networks:


### PR DESCRIPTION
## Summary

Enable Grafana metrics monitoring for gNB regardless of deployment location (Docker, Host, Kubernetes, or Remote server).

## Changes

- **docker-compose.ui.yml**: Add `extra_hosts` for `host.docker.internal` support on Linux
- **.env**: Change default `WS_URL` from hardcoded IP (`172.19.1.3:8001`) to Docker DNS (`gnb:8001`)
- **README.md**: Rewrite connection documentation covering all deployment scenarios

## Supported Deployment Scenarios

| Scenario | gNB Location | WS_URL Configuration |
|----------|--------------|----------------------|
| A | Docker (docker-compose.yml) | `gnb:8001` (default) |
| B | Host machine (native build) | `host.docker.internal:8001` |
| C | Kubernetes | `<service>.<namespace>.svc.cluster.local:8001` |
| D | Remote server | `<ip-address>:8001` |

## Key Improvements

- Default value uses Docker DNS (`gnb:8001`) instead of hardcoded IP
- Linux users can now use `host.docker.internal` (via `extra_hosts: host-gateway`)
- Added missing `autostart_stdout_metrics: true` to gNB config requirements
- Troubleshooting table with common issues and solutions
- Reference to official K8s documentation and Helm chart patterns

## Test Plan

- [ ] Verify Scenario A: gNB + monitoring both in Docker
- [ ] Verify Scenario B: gNB on host, monitoring in Docker
- [ ] Verify `host.docker.internal` resolves correctly on Linux
- [ ] Verify documentation is clear and accurate

Fixes #1422