### PR TITLE
Implement GTP-U Error Indication for Downlink Packets with Unknown TEID (TS 29.281 Compliance)

### DIFF
--- a/include/srsran/gtpu/gtpu_demux.h
+++ b/include/srsran/gtpu/gtpu_demux.h
@@ -26,6 +26,7 @@
 #include "srsran/adt/byte_buffer.h"
 #include "srsran/gtpu/gtpu_teid.h"
 #include "srsran/gtpu/gtpu_tunnel_common_rx.h"
+#include "srsran/gtpu/gtpu_tunnel_common_tx.h"
 #include "srsran/support/executors/task_executor.h"
 #include <sys/socket.h>
 
@@ -77,6 +78,11 @@ public:
 
   /// \brief Mark GTP-U demux as stopped.
   virtual void stop() = 0;
+
+  /// \brief Set the TX notifier and local address for sending GTP-U Error Indication messages.
+  /// Ref: TS 29.281 Sec. 7.3.1.
+  virtual void set_error_indication_tx(gtpu_tunnel_common_tx_upper_layer_notifier& tx_upper,
+                                       const std::string&                          local_addr) = 0;
 };
 
 /// Combined entry point for the GTPU-demux object.

--- a/lib/cu_up/cu_up_impl.cpp
+++ b/lib/cu_up/cu_up_impl.cpp
@@ -124,6 +124,14 @@ cu_up::cu_up(const cu_up_config& config_, const cu_up_dependencies& dependencies
   // We use the first UDP GW for UL.
   gtpu_gw_adapter.connect_network_gateway(*ngu_sessions[0]);
 
+  // Configure GTP-U Error Indication TX on the demux.
+  {
+    std::string n3_bind_addr;
+    if (ngu_sessions[0]->get_bind_address(n3_bind_addr)) {
+      ngu_demux->set_error_indication_tx(gtpu_gw_adapter, n3_bind_addr);
+    }
+  }
+
   // Create N3 TEID allocator
   gtpu_allocator_creation_request n3_alloc_msg = {};
   n3_alloc_msg.max_nof_teids                   = MAX_NOF_UES * MAX_NOF_PDU_SESSIONS;

--- a/lib/gtpu/gtpu_demux_impl.h
+++ b/lib/gtpu/gtpu_demux_impl.h
@@ -82,9 +82,11 @@ private:
   srslog::basic_logger& logger;
 
   // Error Indication TX support
-  gtpu_tunnel_common_tx_upper_layer_notifier* tx_upper_ = nullptr;
-  std::string                                 local_addr_;
-  uint16_t                                    ei_sn_next_ = 0;
+  gtpu_tunnel_common_tx_upper_layer_notifier* tx_upper      = nullptr;
+  gtpu_ie_gtpu_peer_address                   ei_peer_addr  = {};
+  uint16_t                                    ei_sn_next    = 0;
+  gtpu_tunnel_logger                          ei_logger{"GTPU",
+                                                        {gtpu_tunnel_log_prefix{{}, GTPU_PATH_MANAGEMENT_TEID, "UL"}}};
 };
 
 } // namespace srsran

--- a/lib/gtpu/gtpu_demux_impl.h
+++ b/lib/gtpu/gtpu_demux_impl.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "gtpu_pdu.h"
+#include "gtpu_tunnel_logger.h"
 #include "srsran/gtpu/gtpu_demux.h"
 #include "srsran/pcap/dlt_pcap.h"
 #include "srsran/srslog/srslog.h"
@@ -57,7 +59,11 @@ public:
 
   void stop() override;
 
+  void set_error_indication_tx(gtpu_tunnel_common_tx_upper_layer_notifier& tx_upper,
+                               const std::string&                          local_addr) override;
+
 private:
+  void send_error_indication(uint32_t teid, const sockaddr_storage& src_addr);
   // Actual demuxing, to be run in CU-UP executor.
   void handle_pdu_impl(gtpu_teid_t teid, gtpu_demux_pdu_ctx_t pdu_ctx);
 
@@ -74,6 +80,11 @@ private:
   gtpu_teid_t test_teid{0x01};
 
   srslog::basic_logger& logger;
+
+  // Error Indication TX support
+  gtpu_tunnel_common_tx_upper_layer_notifier* tx_upper_ = nullptr;
+  std::string                                 local_addr_;
+  uint16_t                                    ei_sn_next_ = 0;
 };
 
 } // namespace srsran

--- a/lib/gtpu/gtpu_pdu.h
+++ b/lib/gtpu/gtpu_pdu.h
@@ -285,6 +285,22 @@ bool gtpu_write_ie_private_extension(byte_buffer&               pdu,
                                      gtpu_ie_private_extension& ie_priv_ext,
                                      gtpu_tunnel_logger&        logger);
 
+/// Append the "Tunnel Endpoint Identifier Data I" information element to a GTP-U PDU.
+/// Ref: TS 29.281 Sec. 8.3.
+/// \param[out] pdu Buffer of the GTP-U PDU to which the information element shall be appended.
+/// \param[in] ie The information element "Tunnel Endpoint Identifier Data I".
+/// \param[in] logger Access to the logger.
+/// \return True if write was successful, False otherwise.
+bool gtpu_write_ie_teid_i(byte_buffer& pdu, const gtpu_ie_teid_i& ie, gtpu_tunnel_logger& logger);
+
+/// Append the "GTP-U Peer Address" information element to a GTP-U PDU.
+/// Ref: TS 29.281 Sec. 8.4.
+/// \param[out] pdu Buffer of the GTP-U PDU to which the information element shall be appended.
+/// \param[in] ie The information element "GTP-U Peer Address".
+/// \param[in] logger Access to the logger.
+/// \return True if write was successful, False otherwise.
+bool gtpu_write_ie_gtpu_peer_address(byte_buffer& pdu, const gtpu_ie_gtpu_peer_address& ie, gtpu_tunnel_logger& logger);
+
 bool gtpu_supported_flags_check(const gtpu_header& header, gtpu_tunnel_logger& logger);
 bool gtpu_supported_msg_type_check(const gtpu_header& header, gtpu_tunnel_logger& logger);
 bool gtpu_extension_header_comprehension_check(const gtpu_extension_header_type& type, gtpu_tunnel_logger& logger);

--- a/tests/unittests/cu_up/cu_up_test_helpers.h
+++ b/tests/unittests/cu_up/cu_up_test_helpers.h
@@ -111,6 +111,9 @@ public:
 
   void stop() override {}
 
+  void set_error_indication_tx(gtpu_tunnel_common_tx_upper_layer_notifier& tx_upper,
+                               const std::string&                          local_addr) override {}
+
   std::list<gtpu_teid_t> created_teid_list = {};
   std::list<gtpu_teid_t> removed_teid_list = {};
 


### PR DESCRIPTION
Thanks for your great work!
 
This PR adds missing GTP-U error handling logic in the gNB to comply with 3GPP TS 29.281: when a downlink G-PDU arrives with a TEID that is not all zeros and there is no associated tunnel/PDU session context for that TEID, the gNB must discard the packet and send a GTP-U Error Indication back to the originating peer (UPF). The current implementation drops such downlink packets without generating an Error Indication, so this change implements the required behavior and transmits a standards-compliant GTP-U Error Indication message to the UPF, including the required IEs such as the GTP-U peer address and the TEID value from the received packet. 

* Section 7.3.1 of TS 29.281
<img width="827" height="246" alt="image" src="https://github.com/user-attachments/assets/24d19ee5-6a65-4dea-b974-c6464f76b4d5" />

I validated the change in an end-to-end Kubernetes deployment with an Open5GS core by monitoring the AMF/SMF pod logs and confirming that the gNB sends the Error Indication toward the core and that the core-side error handling logic is triggered accordingly.

* gNB log
<img width="969" height="91" alt="Screenshot 2026-02-08 at 4 37 05 PM" src="https://github.com/user-attachments/assets/4c703cfb-4abc-4dff-82bc-bf2ad2187846" />

* AMF log
<img width="1010" height="58" alt="Screenshot 2026-02-08 at 4 38 34 PM" src="https://github.com/user-attachments/assets/d692f882-5776-4f31-b950-698965098039" />

* SMF log
<img width="1170" height="92" alt="Screenshot 2026-02-08 at 4 40 04 PM" src="https://github.com/user-attachments/assets/cca23f0b-d8c9-447c-a7de-4af56ea5b647" />


FYI) I sent my individual CLA